### PR TITLE
fix: downgrade flutter to 3.0.5

### DIFF
--- a/flutter-android/Dockerfile
+++ b/flutter-android/Dockerfile
@@ -22,7 +22,7 @@ RUN cd Android/sdk/cmdline-tools/latest/bin && ./sdkmanager "cmdline-tools;lates
 ENV PATH "$PATH:/home/developer/Android/sdk/platform-tools"
 
 # Download Flutter SDK
-RUN git clone https://github.com/flutter/flutter.git
+RUN git clone -b 3.0.5 https://github.com/flutter/flutter.git
 ENV PATH "$PATH:/home/developer/flutter/bin"
 
 # Run basic check to download Dark SDK


### PR DESCRIPTION
This PR is to fix build issues. Previous build uses version 3.1.0-0.0.pre.1700, that causes dependency error.
Flutter is downgraded to version 3.0.5, which fixes this issue.